### PR TITLE
feat: add parallel downloads, batch processing, and retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ uv tool install yt-audio-cli
 # Single video (saves as MP3 by default)
 yt-audio-cli https://youtube.com/watch?v=VIDEO_ID
 
-# Multiple videos
+# Multiple videos (downloaded in parallel)
 yt-audio-cli URL1 URL2 URL3
 
 # Entire playlist
 yt-audio-cli https://youtube.com/playlist?list=PLAYLIST_ID
+
+# From a batch file (one URL per line)
+yt-audio-cli --batch urls.txt
 ```
 
 ### Choose Format
@@ -101,6 +104,47 @@ yt-audio-cli -o ~/Music URL
 yt-audio-cli --no-metadata URL
 ```
 
+### Parallel Downloads
+
+```bash
+# Use 8 concurrent workers (default: 4)
+yt-audio-cli -w 8 URL1 URL2 URL3
+
+# Single-threaded download
+yt-audio-cli -w 1 URL
+```
+
+### Batch File
+
+```bash
+# Download from a file containing URLs (one per line)
+yt-audio-cli --batch urls.txt
+
+# Combine batch file with additional URLs
+yt-audio-cli --batch urls.txt https://youtube.com/watch?v=EXTRA
+```
+
+Batch file format:
+
+```text
+# Comments start with #
+https://youtube.com/watch?v=VIDEO1
+https://youtube.com/watch?v=VIDEO2
+
+# Blank lines are ignored
+https://youtube.com/watch?v=VIDEO3
+```
+
+### Retry Failed Downloads
+
+```bash
+# Retry failed downloads up to 5 times (default: 3)
+yt-audio-cli -r 5 URL
+
+# Disable retries
+yt-audio-cli -r 0 URL
+```
+
 ## Options
 
 | Option          | Short | Description                        | Default     |
@@ -108,11 +152,14 @@ yt-audio-cli --no-metadata URL
 | `--format`      | `-f`  | Audio format (mp3, aac, opus, wav) | mp3         |
 | `--output`      | `-o`  | Output directory                   | Current dir |
 | `--quality`     | `-q`  | Quality preset (best, good, small) | best        |
-| `--bitrate`     | `-b`  | Exact bitrate in kbps (32-320)     | -           |
+| `--bitrate`     |       | Exact bitrate in kbps (32-320)     | -           |
+| `--workers`     | `-w`  | Concurrent download workers (1-16) | 4           |
+| `--retries`     | `-r`  | Retry attempts for failures (0-10) | 3           |
+| `--batch`       | `-b`  | Path to file containing URLs       | -           |
 | `--no-metadata` |       | Skip embedding metadata            | -           |
 | `--force`       | `-F`  | Re-download even if file exists    | -           |
 | `--version`     | `-v`  | Show version                       | -           |
-| `--help`        | `-h`  | Show help                          | -           |
+| `--help`        |       | Show help                          | -           |
 
 > **Note:** By default, files that already exist in the output directory are skipped. Use `--force` to re-download them.
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Check your internet connection and verify the URL is correct. If the issue persi
 ```python
 __metadata__ = {
     "name": "yt-audio-cli",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "author": "pyyupsk",
     "license": "MIT",
     "python": ">=3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yt-audio-cli"
-version = "0.1.1"
+version = "0.2.0"
 description = "A simple command-line tool for downloading audio from YouTube and other sites"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/yt_audio_cli/__init__.py
+++ b/src/yt_audio_cli/__init__.py
@@ -2,7 +2,7 @@
 
 from yt_audio_cli.core import ConversionError, DownloadError, FFmpegNotFoundError
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 __metadata__ = {
     "name": "yt-audio-cli",
     "version": __version__,

--- a/src/yt_audio_cli/batch/__init__.py
+++ b/src/yt_audio_cli/batch/__init__.py
@@ -1,0 +1,43 @@
+"""Batch processing module for parallel downloads."""
+
+from __future__ import annotations
+
+from yt_audio_cli.batch.executor import (
+    WorkerPool,
+    WorkerState,
+    install_signal_handlers,
+    is_shutdown_requested,
+    reset_shutdown,
+)
+from yt_audio_cli.batch.job import DownloadJob, JobStatus, ProgressUpdate
+from yt_audio_cli.batch.request import (
+    BatchRequest,
+    BatchResult,
+    deduplicate_urls,
+    normalize_url,
+    parse_batch_file,
+)
+from yt_audio_cli.batch.retry import (
+    RetryConfig,
+    is_permanent_error,
+    is_retryable_error,
+)
+
+__all__ = [
+    "BatchRequest",
+    "BatchResult",
+    "DownloadJob",
+    "JobStatus",
+    "ProgressUpdate",
+    "RetryConfig",
+    "WorkerPool",
+    "WorkerState",
+    "deduplicate_urls",
+    "install_signal_handlers",
+    "is_permanent_error",
+    "is_retryable_error",
+    "is_shutdown_requested",
+    "normalize_url",
+    "parse_batch_file",
+    "reset_shutdown",
+]

--- a/src/yt_audio_cli/batch/__init__.py
+++ b/src/yt_audio_cli/batch/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from yt_audio_cli.batch.executor import (
+    CompletionResult,
     WorkerPool,
     WorkerState,
     install_signal_handlers,
@@ -26,6 +27,7 @@ from yt_audio_cli.batch.retry import (
 __all__ = [
     "BatchRequest",
     "BatchResult",
+    "CompletionResult",
     "DownloadJob",
     "JobStatus",
     "ProgressUpdate",

--- a/src/yt_audio_cli/batch/executor.py
+++ b/src/yt_audio_cli/batch/executor.py
@@ -1,0 +1,242 @@
+"""Worker pool executor for parallel downloads."""
+
+from __future__ import annotations
+
+import signal
+import sys
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from threading import Event
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from yt_audio_cli.batch.job import DownloadJob
+
+# Global shutdown event for signal handling
+shutdown_event = Event()
+
+# Track if signal handlers have been installed
+_handlers_installed = False
+
+
+def _signal_handler(_signum: int, _frame: object) -> None:
+    """Handle SIGINT/SIGTERM for graceful shutdown."""
+    shutdown_event.set()
+
+
+def install_signal_handlers() -> None:
+    """Install signal handlers for graceful shutdown.
+
+    Safe to call multiple times - handlers are only installed once.
+    """
+    global _handlers_installed
+    if _handlers_installed:
+        return
+
+    # Only install on main thread
+    try:
+        if sys.platform != "win32":
+            signal.signal(signal.SIGINT, _signal_handler)
+            signal.signal(signal.SIGTERM, _signal_handler)
+        else:
+            # Windows only supports SIGINT
+            signal.signal(signal.SIGINT, _signal_handler)
+        _handlers_installed = True
+    except ValueError:
+        # Not on main thread, skip signal handling
+        pass
+
+
+def is_shutdown_requested() -> bool:
+    """Check if shutdown has been requested.
+
+    Returns:
+        True if SIGINT/SIGTERM was received.
+    """
+    return shutdown_event.is_set()
+
+
+def reset_shutdown() -> None:
+    """Reset the shutdown event.
+
+    Useful for testing or restarting batch operations.
+    """
+    shutdown_event.clear()
+
+
+@dataclass
+class WorkerState:
+    """Current state of a download worker.
+
+    Attributes:
+        worker_id: Unique identifier for this worker.
+        job: Current job being processed, or None if idle.
+    """
+
+    worker_id: int
+    job: DownloadJob | None = None
+
+    @property
+    def is_idle(self) -> bool:
+        """Check if worker is idle (not processing a job)."""
+        return self.job is None
+
+    @property
+    def display_line(self) -> str:
+        """Get a single-line status display for this worker."""
+        if self.is_idle:
+            return f"[{self.worker_id}] Idle"
+
+        job = self.job
+        assert job is not None  # nosec B101 - guarded by is_idle check above
+        title = job.current_title[:40] if job.current_title else "Unknown"
+        return f"[{self.worker_id}] {title:40} {job.current_percent:3}%"
+
+
+@dataclass
+class WorkerPool[T]:
+    """Thread pool wrapper for parallel job execution.
+
+    Manages a ThreadPoolExecutor and tracks worker states for
+    progress display purposes.
+
+    Attributes:
+        max_workers: Maximum number of concurrent workers.
+        worker_states: Current state of each worker.
+    """
+
+    max_workers: int
+    worker_states: dict[int, WorkerState] = field(default_factory=dict)
+    _executor: ThreadPoolExecutor | None = field(default=None, init=False, repr=False)
+    _futures: dict[Future[T], int] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize worker states."""
+        for i in range(self.max_workers):
+            self.worker_states[i] = WorkerState(worker_id=i)
+
+    def __enter__(self) -> WorkerPool[T]:
+        """Enter context manager - start the executor."""
+        install_signal_handlers()
+        self._executor = ThreadPoolExecutor(max_workers=self.max_workers)
+        return self
+
+    def __exit__(
+        self, exc_type: type | None, exc_val: Exception | None, exc_tb: object
+    ) -> None:
+        """Exit context manager - shutdown executor gracefully."""
+        if self._executor:
+            self._executor.shutdown(wait=True, cancel_futures=True)
+            self._executor = None
+
+    def submit(
+        self,
+        fn: Callable[..., T],
+        *args: object,
+        worker_id: int | None = None,
+        **kwargs: object,
+    ) -> Future[T] | None:
+        """Submit a task for execution.
+
+        Args:
+            fn: Function to execute.
+            *args: Positional arguments for fn.
+            worker_id: Optional worker ID to associate with this task.
+            **kwargs: Keyword arguments for fn.
+
+        Returns:
+            Future for the submitted task, or None if shutdown requested.
+        """
+        if is_shutdown_requested():
+            return None
+
+        if self._executor is None:
+            raise RuntimeError("WorkerPool must be used as context manager")
+
+        future = self._executor.submit(fn, *args, **kwargs)
+
+        if worker_id is not None:
+            self._futures[future] = worker_id
+
+        return future
+
+    def submit_job(
+        self,
+        job: DownloadJob,
+        fn: Callable[[DownloadJob, int], T],
+        worker_id: int,
+    ) -> Future[T] | None:
+        """Submit a download job for execution.
+
+        Updates worker state to track the job being processed.
+
+        Args:
+            job: The download job to process.
+            fn: Function to execute, takes (job, worker_id).
+            worker_id: Worker ID to associate with this job.
+
+        Returns:
+            Future for the submitted task, or None if shutdown requested.
+        """
+        if is_shutdown_requested():
+            return None
+
+        # Update worker state
+        if worker_id in self.worker_states:
+            self.worker_states[worker_id].job = job
+
+        return self.submit(fn, job, worker_id, worker_id=worker_id)
+
+    def mark_worker_idle(self, worker_id: int) -> None:
+        """Mark a worker as idle after completing a job."""
+        if worker_id in self.worker_states:
+            self.worker_states[worker_id].job = None
+
+    def get_active_workers(self) -> list[WorkerState]:
+        """Get list of workers currently processing jobs."""
+        return [ws for ws in self.worker_states.values() if not ws.is_idle]
+
+    def get_idle_workers(self) -> list[int]:
+        """Get list of idle worker IDs."""
+        return [ws.worker_id for ws in self.worker_states.values() if ws.is_idle]
+
+    def wait_for_completion(
+        self,
+        futures: list[Future[T]],
+        callback: Callable[[Future[T], int | None], None] | None = None,
+    ) -> list[T]:
+        """Wait for futures to complete and collect results.
+
+        Args:
+            futures: List of futures to wait for.
+            callback: Optional callback called when each future completes.
+                Takes (future, worker_id) as arguments.
+
+        Returns:
+            List of results from completed futures.
+        """
+        results: list[T] = []
+
+        for future in as_completed(futures):
+            worker_id = self._futures.get(future)
+
+            if callback:
+                callback(future, worker_id)
+
+            if worker_id is not None:
+                self.mark_worker_idle(worker_id)
+
+            try:
+                result = future.result()
+                results.append(result)
+            except Exception:  # nosec B110 - Error handling delegated to callback
+                pass
+
+        return results
+
+    def shutdown(self) -> None:
+        """Request graceful shutdown of the worker pool."""
+        shutdown_event.set()
+        if self._executor:
+            self._executor.shutdown(wait=False, cancel_futures=True)

--- a/src/yt_audio_cli/batch/job.py
+++ b/src/yt_audio_cli/batch/job.py
@@ -1,0 +1,121 @@
+"""Download job entity for batch processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Literal
+
+
+class JobStatus(Enum):
+    """Status of a download job."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    COMPLETE = "complete"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class DownloadJob:
+    """Single download task in a batch.
+
+    Attributes:
+        url: The URL to download.
+        output_dir: Directory for output files.
+        format: Target audio format.
+        status: Current job status.
+        retry_count: Number of retry attempts made.
+        error_message: Error message if job failed.
+        output_path: Path to the output file if successful.
+        current_percent: Current download progress (0-100).
+        current_title: Title of the current download.
+    """
+
+    url: str
+    output_dir: Path
+    format: str = "mp3"
+
+    # Runtime state
+    status: JobStatus = field(default=JobStatus.PENDING)
+    retry_count: int = 0
+    error_message: str | None = None
+    output_path: Path | None = None
+
+    # Progress tracking (lightweight, no history)
+    current_percent: int = 0
+    current_title: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate job fields after initialization."""
+        if not self.url.startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL: {self.url}")
+        if self.retry_count < 0:
+            raise ValueError(f"retry_count must be >= 0, got {self.retry_count}")
+        if not 0 <= self.current_percent <= 100:
+            self.current_percent = max(0, min(100, self.current_percent))
+
+    def mark_active(self, title: str = "") -> None:
+        """Mark job as active (started downloading)."""
+        self.status = JobStatus.ACTIVE
+        self.current_percent = 0
+        if title:
+            self.current_title = title
+
+    def mark_complete(self, output_path: Path) -> None:
+        """Mark job as successfully completed."""
+        self.status = JobStatus.COMPLETE
+        self.output_path = output_path
+        self.current_percent = 100
+        self.error_message = None
+
+    def mark_failed(self, error: str) -> None:
+        """Mark job as failed."""
+        self.status = JobStatus.FAILED
+        self.error_message = error
+
+    def mark_cancelled(self) -> None:
+        """Mark job as cancelled."""
+        self.status = JobStatus.CANCELLED
+
+    def update_progress(self, percent: int, title: str = "") -> None:
+        """Update download progress."""
+        self.current_percent = max(0, min(100, percent))
+        if title:
+            self.current_title = title
+
+    def increment_retry(self) -> None:
+        """Increment retry count and reset for retry."""
+        self.retry_count += 1
+        self.status = JobStatus.PENDING
+        self.current_percent = 0
+        self.error_message = None
+
+
+@dataclass(frozen=True)
+class ProgressUpdate:
+    """Progress update message from worker to display.
+
+    Immutable message for thread-safe producer-consumer pattern.
+
+    Attributes:
+        worker_id: ID of the worker sending the update.
+        job_url: URL of the job being processed.
+        event: Type of progress event.
+        percent: Download progress percentage (for "progress" events).
+        title: Title of the content being downloaded.
+        error: Error message (for "failed" events).
+    """
+
+    worker_id: int
+    job_url: str
+    event: Literal["started", "progress", "complete", "failed"]
+
+    # Only for "progress" events
+    percent: int = 0
+    title: str = ""
+
+    # Only for "failed" events
+    error: str = ""

--- a/src/yt_audio_cli/batch/request.py
+++ b/src/yt_audio_cli/batch/request.py
@@ -1,0 +1,288 @@
+"""Batch request and result entities."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import ParseResult, parse_qs, urlparse
+
+from yt_audio_cli.batch.job import DownloadJob, JobStatus
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class BatchRequest:
+    """Collection of download jobs to process.
+
+    Thread-safe aggregate counters for tracking batch progress.
+
+    Attributes:
+        jobs: List of download jobs to process.
+        max_workers: Number of concurrent workers.
+        max_retries: Maximum retry attempts per job.
+    """
+
+    jobs: list[DownloadJob] = field(default_factory=list)
+    max_workers: int = 4
+    max_retries: int = 3
+
+    # Private thread-safe counters
+    _completed: int = field(default=0, init=False, repr=False)
+    _failed: int = field(default=0, init=False, repr=False)
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        """Validate configuration."""
+        if self.max_workers < 1:
+            raise ValueError(f"max_workers must be >= 1, got {self.max_workers}")
+        if self.max_workers > 16:
+            raise ValueError(f"max_workers must be <= 16, got {self.max_workers}")
+        if self.max_retries < 0:
+            raise ValueError(f"max_retries must be >= 0, got {self.max_retries}")
+        if self.max_retries > 10:
+            raise ValueError(f"max_retries must be <= 10, got {self.max_retries}")
+
+    @property
+    def total(self) -> int:
+        """Total number of jobs."""
+        return len(self.jobs)
+
+    @property
+    def completed(self) -> int:
+        """Number of successfully completed jobs (thread-safe)."""
+        with self._lock:
+            return self._completed
+
+    @property
+    def failed(self) -> int:
+        """Number of failed jobs (thread-safe)."""
+        with self._lock:
+            return self._failed
+
+    @property
+    def pending(self) -> int:
+        """Number of pending jobs."""
+        with self._lock:
+            return self.total - self._completed - self._failed
+
+    def increment_completed(self) -> None:
+        """Increment completed counter (thread-safe)."""
+        with self._lock:
+            self._completed += 1
+
+    def increment_failed(self) -> None:
+        """Increment failed counter (thread-safe)."""
+        with self._lock:
+            self._failed += 1
+
+    def pending_jobs(self) -> Iterator[DownloadJob]:
+        """Yield jobs that need processing (pending or eligible for retry).
+
+        Jobs that have failed but haven't exhausted retries are reset to
+        pending and yielded again.
+
+        Yields:
+            DownloadJob instances that are ready to be processed.
+        """
+        for job in self.jobs:
+            if job.status == JobStatus.PENDING:
+                yield job
+            elif job.status == JobStatus.FAILED and job.retry_count < self.max_retries:
+                job.status = JobStatus.PENDING
+                yield job
+
+    def add_job(self, url: str, output_dir: Path, audio_format: str = "mp3") -> None:
+        """Add a new job to the batch.
+
+        Args:
+            url: URL to download.
+            output_dir: Output directory.
+            audio_format: Target audio format.
+        """
+        job = DownloadJob(url=url, output_dir=output_dir, format=audio_format)
+        self.jobs.append(job)
+
+
+@dataclass
+class BatchResult:
+    """Summary of batch processing outcome.
+
+    Attributes:
+        total: Total number of jobs processed.
+        successful: Number of successfully completed jobs.
+        failed: Number of failed jobs.
+        skipped_duplicates: Number of duplicate URLs skipped.
+        successful_files: List of paths to successfully downloaded files.
+        failed_jobs: List of jobs that failed for error reporting.
+    """
+
+    total: int
+    successful: int
+    failed: int
+    skipped_duplicates: int
+
+    successful_files: list[Path] = field(default_factory=list)
+    failed_jobs: list[DownloadJob] = field(default_factory=list)
+
+    @property
+    def success_rate(self) -> float:
+        """Calculate success rate as a decimal (0.0 to 1.0)."""
+        if self.total == 0:
+            return 1.0
+        return self.successful / self.total
+
+    @property
+    def has_failures(self) -> bool:
+        """Check if any jobs failed."""
+        return self.failed > 0
+
+    @classmethod
+    def from_request(cls, request: BatchRequest, skipped: int = 0) -> BatchResult:
+        """Create result from a completed batch request.
+
+        Args:
+            request: The completed batch request.
+            skipped: Number of duplicates skipped.
+
+        Returns:
+            BatchResult summarizing the batch processing.
+        """
+        successful_files: list[Path] = []
+        failed_jobs: list[DownloadJob] = []
+
+        for job in request.jobs:
+            if job.status == JobStatus.COMPLETE and job.output_path:
+                successful_files.append(job.output_path)
+            elif job.status == JobStatus.FAILED:
+                failed_jobs.append(job)
+
+        return cls(
+            total=request.total,
+            successful=len(successful_files),
+            failed=len(failed_jobs),
+            skipped_duplicates=skipped,
+            successful_files=successful_files,
+            failed_jobs=failed_jobs,
+        )
+
+
+def parse_batch_file(path: Path) -> list[str]:
+    """Parse a batch file containing URLs.
+
+    Reads a text file with one URL per line, ignoring blank lines
+    and lines starting with #.
+
+    Args:
+        path: Path to the batch file.
+
+    Returns:
+        List of URLs from the file.
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist.
+        ValueError: If the file is empty or contains no valid URLs.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Batch file not found: {path}")
+
+    urls: list[str] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            urls.append(line)
+
+    if not urls:
+        raise ValueError(f"Batch file is empty: {path}")
+
+    return urls
+
+
+def normalize_url(url: str) -> str:
+    """Normalize a URL for duplicate detection.
+
+    Handles YouTube-specific URL variations (youtu.be, youtube.com, etc.)
+    to detect duplicates regardless of URL format.
+
+    Args:
+        url: The URL to normalize.
+
+    Returns:
+        Normalized URL string for comparison.
+    """
+    url = url.strip().rstrip("/")
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return url
+
+    # YouTube-specific normalization
+    host = parsed.netloc.lower()
+    if "youtube.com" in host or "youtu.be" in host:
+        video_id = _extract_youtube_video_id(parsed)
+        if video_id:
+            return f"youtube:{video_id}"
+
+    return url
+
+
+def _extract_youtube_video_id(parsed: ParseResult) -> str | None:
+    """Extract YouTube video ID from various URL formats.
+
+    Args:
+        parsed: Parsed URL object.
+
+    Returns:
+        Video ID if found, None otherwise.
+    """
+    # youtube.com/watch?v=VIDEO_ID
+    query_params = parse_qs(parsed.query)
+    if "v" in query_params:
+        return query_params["v"][0]
+
+    # youtu.be/VIDEO_ID
+    if "youtu.be" in parsed.netloc:
+        path = parsed.path.strip("/")
+        if path and "/" not in path:
+            return path
+
+    # youtube.com/embed/VIDEO_ID or youtube.com/v/VIDEO_ID
+    path_parts = parsed.path.strip("/").split("/")
+    if len(path_parts) >= 2 and path_parts[0] in ("embed", "v"):
+        return path_parts[1]
+
+    return None
+
+
+def deduplicate_urls(urls: list[str]) -> tuple[list[str], list[str]]:
+    """Deduplicate a list of URLs.
+
+    Uses URL normalization to detect duplicates even when URLs
+    use different formats for the same content.
+
+    Args:
+        urls: List of URLs to deduplicate.
+
+    Returns:
+        Tuple of (unique_urls, duplicate_urls).
+    """
+    seen: set[str] = set()
+    unique: list[str] = []
+    duplicates: list[str] = []
+
+    for url in urls:
+        normalized = normalize_url(url)
+        if normalized in seen:
+            duplicates.append(url)
+        else:
+            seen.add(normalized)
+            unique.append(url)
+
+    return unique, duplicates

--- a/src/yt_audio_cli/batch/retry.py
+++ b/src/yt_audio_cli/batch/retry.py
@@ -1,0 +1,151 @@
+"""Retry configuration and exponential backoff logic."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+# Error patterns that indicate transient/retryable failures
+RETRYABLE_PATTERNS = frozenset(
+    {
+        "timeout",
+        "connection reset",
+        "temporary failure",
+        "429",
+        "too many requests",
+        "503",
+        "service unavailable",
+        "network",
+        "timed out",
+        "connection refused",
+        "connection error",
+        "ssl error",
+        "read timeout",
+        "write timeout",
+    }
+)
+
+# Error patterns that indicate permanent failures (no retry)
+PERMANENT_PATTERNS = frozenset(
+    {
+        "404",
+        "not found",
+        "video unavailable",
+        "private video",
+        "is private",
+        "age restricted",
+        "age-restricted",
+        "copyright",
+        "removed",
+        "deleted",
+        "blocked",
+        "geo restricted",
+        "members only",
+        "available to members",
+        "sign in",
+        "login required",
+        "invalid url",
+        "unsupported url",
+    }
+)
+
+
+@dataclass
+class RetryConfig:
+    """Retry behavior configuration.
+
+    Attributes:
+        max_attempts: Maximum number of retry attempts (1 = no retries).
+        base_delay: Base delay in seconds for exponential backoff.
+        max_delay: Maximum delay cap in seconds.
+        jitter: Whether to add random jitter to delays.
+    """
+
+    max_attempts: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 30.0
+    jitter: bool = True
+
+    def __post_init__(self) -> None:
+        """Validate configuration."""
+        if self.max_attempts < 1:
+            raise ValueError(f"max_attempts must be >= 1, got {self.max_attempts}")
+        if self.max_attempts > 10:
+            raise ValueError(f"max_attempts must be <= 10, got {self.max_attempts}")
+        if self.base_delay < 0:
+            raise ValueError(f"base_delay must be >= 0, got {self.base_delay}")
+        if self.max_delay < self.base_delay:
+            raise ValueError(
+                f"max_delay ({self.max_delay}) must be >= base_delay ({self.base_delay})"
+            )
+
+    def delay_for_attempt(self, attempt: int) -> float:
+        """Calculate delay for given attempt number.
+
+        Uses exponential backoff: delay = min(base * 2^attempt, max_delay)
+        With optional jitter: delay += random(0, 1)
+
+        Args:
+            attempt: The attempt number (0-indexed).
+
+        Returns:
+            Delay in seconds before the next retry.
+        """
+        if attempt < 0:
+            attempt = 0
+
+        delay = min(self.base_delay * (2**attempt), self.max_delay)
+
+        if self.jitter:
+            delay += random.uniform(0, 1)  # nosec B311 - jitter, not security
+
+        return delay
+
+    def should_retry(self, attempt: int) -> bool:
+        """Check if another retry attempt should be made.
+
+        Args:
+            attempt: The current attempt number (0-indexed).
+
+        Returns:
+            True if more retries are allowed.
+        """
+        return attempt < self.max_attempts - 1
+
+
+def is_retryable_error(error: str) -> bool:
+    """Check if an error is retryable (transient).
+
+    Args:
+        error: The error message to check.
+
+    Returns:
+        True if the error appears to be transient and worth retrying.
+    """
+    if not error:
+        return False
+
+    error_lower = error.lower()
+
+    # First check if it's a permanent error
+    if is_permanent_error(error):
+        return False
+
+    # Check for retryable patterns
+    return any(pattern in error_lower for pattern in RETRYABLE_PATTERNS)
+
+
+def is_permanent_error(error: str) -> bool:
+    """Check if an error is permanent (should not retry).
+
+    Args:
+        error: The error message to check.
+
+    Returns:
+        True if the error appears to be permanent.
+    """
+    if not error:
+        return False
+
+    error_lower = error.lower()
+    return any(pattern in error_lower for pattern in PERMANENT_PATTERNS)

--- a/src/yt_audio_cli/core/__init__.py
+++ b/src/yt_audio_cli/core/__init__.py
@@ -1,17 +1,21 @@
 """Core utilities - errors and filename handling."""
 
 from yt_audio_cli.core.errors import (
+    BatchError,
     ConversionError,
     DownloadError,
     FFmpegNotFoundError,
+    RetryExhaustedError,
     format_error,
 )
 from yt_audio_cli.core.filename import resolve_conflict, sanitize
 
 __all__ = [
+    "BatchError",
     "ConversionError",
     "DownloadError",
     "FFmpegNotFoundError",
+    "RetryExhaustedError",
     "format_error",
     "resolve_conflict",
     "sanitize",

--- a/src/yt_audio_cli/download/__init__.py
+++ b/src/yt_audio_cli/download/__init__.py
@@ -1,5 +1,6 @@
 """Download feature - handles yt-dlp interaction for audio downloads."""
 
+from yt_audio_cli.download.batch import BatchDownloader, download_batch
 from yt_audio_cli.download.downloader import (
     DownloadResult,
     PlaylistEntry,
@@ -11,9 +12,11 @@ from yt_audio_cli.download.downloader import (
 )
 
 __all__ = [
+    "BatchDownloader",
     "DownloadResult",
     "PlaylistEntry",
     "download",
+    "download_batch",
     "extract_metadata",
     "extract_playlist",
     "extract_playlist_with_metadata",

--- a/src/yt_audio_cli/download/batch.py
+++ b/src/yt_audio_cli/download/batch.py
@@ -16,7 +16,7 @@ from yt_audio_cli.batch.request import BatchRequest, BatchResult
 from yt_audio_cli.batch.retry import RetryConfig, is_permanent_error, is_retryable_error
 from yt_audio_cli.convert import transcode
 from yt_audio_cli.core import resolve_conflict, sanitize
-from yt_audio_cli.download import DownloadResult, download
+from yt_audio_cli.download.downloader import DownloadResult, download
 
 if TYPE_CHECKING:
     pass
@@ -162,12 +162,16 @@ class BatchDownloader:
         Returns:
             Output path if successful, None otherwise.
         """
+        import uuid
+
         sanitized_title = sanitize(result.title)
         final_output_path = self.output_dir / f"{sanitized_title}.{self.audio_format}"
         final_output_path = resolve_conflict(final_output_path)
 
+        # Use UUID to avoid conflicts between parallel jobs
+        unique_id = uuid.uuid4().hex[:8]
         temp_output_path = (
-            self.output_dir / f".{sanitized_title}.{self.audio_format}.tmp"
+            self.output_dir / f".{sanitized_title}_{unique_id}.{self.audio_format}.tmp"
         )
 
         metadata = {}

--- a/src/yt_audio_cli/download/batch.py
+++ b/src/yt_audio_cli/download/batch.py
@@ -1,0 +1,368 @@
+"""Batch download functionality with parallel execution."""
+
+from __future__ import annotations
+
+import contextlib
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from queue import Queue
+from typing import TYPE_CHECKING
+
+from yt_audio_cli.batch.executor import WorkerPool, is_shutdown_requested
+from yt_audio_cli.batch.job import DownloadJob, ProgressUpdate
+from yt_audio_cli.batch.request import BatchRequest, BatchResult
+from yt_audio_cli.batch.retry import RetryConfig, is_permanent_error, is_retryable_error
+from yt_audio_cli.convert import transcode
+from yt_audio_cli.core import resolve_conflict, sanitize
+from yt_audio_cli.download import DownloadResult, download
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class BatchDownloader:
+    """Parallel batch downloader using ThreadPoolExecutor.
+
+    Coordinates parallel download and conversion of multiple URLs
+    with progress reporting and graceful shutdown support.
+
+    Attributes:
+        request: The batch request to process.
+        output_dir: Output directory for converted files.
+        audio_format: Target audio format.
+        bitrate: Target bitrate in kbps.
+        embed_metadata: Whether to embed metadata.
+        retry_config: Retry configuration for failed downloads.
+        progress_queue: Optional queue for progress updates.
+    """
+
+    request: BatchRequest
+    output_dir: Path
+    audio_format: str = "mp3"
+    bitrate: int | None = None
+    embed_metadata: bool = True
+    retry_config: RetryConfig = field(default_factory=RetryConfig)
+    progress_queue: Queue[ProgressUpdate] | None = None
+
+    def _send_progress(
+        self,
+        worker_id: int,
+        job: DownloadJob,
+        event: str,
+        percent: int = 0,
+        error: str = "",
+    ) -> None:
+        """Send a progress update to the queue."""
+        if self.progress_queue is None:
+            return
+
+        update = ProgressUpdate(
+            worker_id=worker_id,
+            job_url=job.url,
+            event=event,  # type: ignore[arg-type]
+            percent=percent,
+            title=job.current_title,
+            error=error,
+        )
+        self.progress_queue.put(update)
+
+    def _download_single(
+        self,
+        job: DownloadJob,
+        worker_id: int,
+    ) -> bool:
+        """Download and convert a single job.
+
+        Handles the full download→convert pipeline for one URL.
+
+        Args:
+            job: The download job to process.
+            worker_id: ID of the worker processing this job.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        if is_shutdown_requested():
+            job.mark_cancelled()
+            return False
+
+        job.mark_active()
+        self._send_progress(worker_id, job, "started")
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+
+            # Download phase
+            def progress_callback(downloaded: int, total: int) -> None:
+                if total > 0:
+                    percent = int((downloaded / total) * 100)
+                    job.update_progress(percent)
+                    self._send_progress(worker_id, job, "progress", percent)
+
+            try:
+                result = download(
+                    url=job.url,
+                    progress_callback=progress_callback,
+                    output_dir=temp_dir,
+                )
+
+                if not result.success:
+                    job.mark_failed(result.error or "Download failed")
+                    self._send_progress(
+                        worker_id, job, "failed", error=result.error or "Unknown error"
+                    )
+                    return False
+
+                if not result.temp_path.exists():
+                    job.mark_failed("Temporary file not found")
+                    self._send_progress(
+                        worker_id, job, "failed", error="Temporary file not found"
+                    )
+                    return False
+
+                # Update title from result
+                if result.title:
+                    job.current_title = result.title
+
+                if is_shutdown_requested():
+                    job.mark_cancelled()
+                    return False
+
+                # Conversion phase
+                output_path = self._convert_audio(result, job, worker_id)
+                if output_path is None:
+                    return False
+
+                job.mark_complete(output_path)
+                self._send_progress(worker_id, job, "complete", 100)
+                return True
+
+            except Exception as e:
+                error_msg = str(e)
+                job.mark_failed(error_msg)
+                self._send_progress(worker_id, job, "failed", error=error_msg)
+                return False
+
+    def _convert_audio(
+        self,
+        result: DownloadResult,
+        job: DownloadJob,
+        worker_id: int,
+    ) -> Path | None:
+        """Convert downloaded audio to target format.
+
+        Args:
+            result: Download result with temp file.
+            job: The download job.
+            worker_id: Worker ID for progress updates.
+
+        Returns:
+            Output path if successful, None otherwise.
+        """
+        sanitized_title = sanitize(result.title)
+        final_output_path = self.output_dir / f"{sanitized_title}.{self.audio_format}"
+        final_output_path = resolve_conflict(final_output_path)
+
+        temp_output_path = (
+            self.output_dir / f".{sanitized_title}.{self.audio_format}.tmp"
+        )
+
+        metadata = {}
+        if self.embed_metadata:
+            metadata = {"title": result.title, "artist": result.artist}
+
+        try:
+            transcode(
+                input_path=result.temp_path,
+                output_path=temp_output_path,
+                audio_format=self.audio_format,
+                bitrate=self.bitrate,
+                embed_metadata=self.embed_metadata,
+                metadata=metadata,
+            )
+
+            if final_output_path.exists():
+                final_output_path = resolve_conflict(final_output_path)
+            temp_output_path.replace(final_output_path)
+            return final_output_path
+
+        except Exception as e:
+            job.mark_failed(f"Conversion failed: {e}")
+            self._send_progress(
+                worker_id, job, "failed", error=f"Conversion failed: {e}"
+            )
+            return None
+        finally:
+            if temp_output_path.exists():
+                with contextlib.suppress(OSError):
+                    temp_output_path.unlink()
+
+    def _process_job_with_retry(
+        self,
+        job: DownloadJob,
+        worker_id: int,
+    ) -> bool:
+        """Process a job with retry logic.
+
+        Args:
+            job: The download job to process.
+            worker_id: Worker ID.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        for attempt in range(self.retry_config.max_attempts):
+            if is_shutdown_requested():
+                job.mark_cancelled()
+                return False
+
+            success = self._download_single(job, worker_id)
+
+            if success:
+                return True
+
+            # Check if we should retry
+            error = job.error_message or ""
+
+            # Don't retry permanent errors
+            if is_permanent_error(error):
+                return False
+
+            # Check if error is retryable
+            if not is_retryable_error(error):
+                return False
+
+            # Check if we have retries left
+            if not self.retry_config.should_retry(attempt):
+                return False
+
+            # Wait before retry
+            delay = self.retry_config.delay_for_attempt(attempt)
+            time.sleep(delay)
+            job.increment_retry()
+
+        return False
+
+    def run(self) -> BatchResult:
+        """Execute the batch download.
+
+        Runs all jobs in parallel using the configured number of workers.
+        Tracks progress and handles failures/retries.
+
+        Returns:
+            BatchResult with summary of the operation.
+        """
+        if not self.request.jobs:
+            return BatchResult(
+                total=0,
+                successful=0,
+                failed=0,
+                skipped_duplicates=0,
+            )
+
+        # Limit workers to number of jobs
+        effective_workers = min(self.request.max_workers, len(self.request.jobs))
+
+        with WorkerPool[bool](max_workers=effective_workers) as pool:
+            job_index = 0
+            pending_futures: dict[object, tuple[DownloadJob, int]] = {}
+
+            # Submit initial batch of jobs
+            for worker_id in range(effective_workers):
+                if job_index < len(self.request.jobs):
+                    job = self.request.jobs[job_index]
+                    future = pool.submit_job(
+                        job, self._process_job_with_retry, worker_id
+                    )
+                    if future:
+                        pending_futures[future] = (job, worker_id)
+                    job_index += 1
+
+            # Process as jobs complete
+            while pending_futures:
+                if is_shutdown_requested():
+                    break
+
+                # Wait for any future to complete
+                done_futures = []
+                for future in list(pending_futures.keys()):
+                    if future.done():  # type: ignore[union-attr]
+                        done_futures.append(future)
+
+                if not done_futures:
+                    time.sleep(0.01)
+                    continue
+
+                for future in done_futures:
+                    job, worker_id = pending_futures.pop(future)
+                    pool.mark_worker_idle(worker_id)
+
+                    try:
+                        success = future.result()  # type: ignore[union-attr]
+                        if success:
+                            self.request.increment_completed()
+                        else:
+                            self.request.increment_failed()
+                    except Exception:
+                        self.request.increment_failed()
+
+                    # Submit next job if available
+                    if job_index < len(self.request.jobs):
+                        next_job = self.request.jobs[job_index]
+                        next_future = pool.submit_job(
+                            next_job, self._process_job_with_retry, worker_id
+                        )
+                        if next_future:
+                            pending_futures[next_future] = (next_job, worker_id)
+                        job_index += 1
+
+        return BatchResult.from_request(self.request)
+
+
+def download_batch(
+    urls: list[str],
+    output_dir: Path,
+    audio_format: str = "mp3",
+    max_workers: int = 4,
+    max_retries: int = 3,
+    bitrate: int | None = None,
+    embed_metadata: bool = True,
+    progress_queue: Queue[ProgressUpdate] | None = None,
+) -> BatchResult:
+    """Download multiple URLs in parallel.
+
+    Convenience function that creates a BatchRequest and BatchDownloader.
+
+    Args:
+        urls: List of URLs to download.
+        output_dir: Output directory for converted files.
+        audio_format: Target audio format.
+        max_workers: Number of concurrent workers.
+        max_retries: Maximum retry attempts per job.
+        bitrate: Target bitrate in kbps.
+        embed_metadata: Whether to embed metadata.
+        progress_queue: Optional queue for progress updates.
+
+    Returns:
+        BatchResult with summary of the operation.
+    """
+    request = BatchRequest(max_workers=max_workers, max_retries=max_retries)
+    for url in urls:
+        request.add_job(url, output_dir, audio_format)
+
+    retry_config = RetryConfig(max_attempts=max_retries + 1)
+
+    downloader = BatchDownloader(
+        request=request,
+        output_dir=output_dir,
+        audio_format=audio_format,
+        bitrate=bitrate,
+        embed_metadata=embed_metadata,
+        retry_config=retry_config,
+        progress_queue=progress_queue,
+    )
+
+    return downloader.run()

--- a/tests/batch/__init__.py
+++ b/tests/batch/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for batch processing module."""

--- a/tests/batch/test_executor.py
+++ b/tests/batch/test_executor.py
@@ -1,0 +1,206 @@
+"""Unit tests for WorkerPool executor."""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import Future
+from pathlib import Path
+
+from yt_audio_cli.batch.executor import (
+    WorkerPool,
+    WorkerState,
+    is_shutdown_requested,
+    reset_shutdown,
+)
+from yt_audio_cli.batch.job import DownloadJob
+
+
+class TestWorkerState:
+    """Tests for WorkerState dataclass."""
+
+    def test_idle_worker(self) -> None:
+        """Test idle worker state."""
+        state = WorkerState(worker_id=0)
+        assert state.is_idle is True
+        assert "Idle" in state.display_line
+
+    def test_active_worker(self, temp_dir: Path) -> None:
+        """Test active worker with a job."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+        job.current_title = "Test Video Title"
+        job.current_percent = 50
+
+        state = WorkerState(worker_id=1, job=job)
+        assert state.is_idle is False
+        assert "50%" in state.display_line
+        assert "Test Video" in state.display_line
+
+    def test_display_line_truncates_title(self, temp_dir: Path) -> None:
+        """Test that long titles are truncated in display line."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+        job.current_title = "A" * 100  # Very long title
+        job.current_percent = 25
+
+        state = WorkerState(worker_id=0, job=job)
+        display = state.display_line
+        # Title should be truncated to 40 chars
+        assert len(display) < 100
+
+
+class TestWorkerPool:
+    """Tests for WorkerPool executor."""
+
+    def setup_method(self) -> None:
+        """Reset shutdown state before each test."""
+        reset_shutdown()
+
+    def test_context_manager(self) -> None:
+        """Test using WorkerPool as context manager."""
+        with WorkerPool[int](max_workers=2) as pool:
+            assert pool._executor is not None
+            assert len(pool.worker_states) == 2
+
+        assert pool._executor is None
+
+    def test_submit_task(self) -> None:
+        """Test submitting a task to the pool."""
+        results: list[int] = []
+
+        def task(x: int) -> int:
+            results.append(x)
+            return x * 2
+
+        with WorkerPool[int](max_workers=2) as pool:
+            future = pool.submit(task, 5)
+            assert future is not None
+            result = future.result()
+            assert result == 10
+            assert 5 in results
+
+    def test_submit_job(self, temp_dir: Path) -> None:
+        """Test submitting a download job."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+
+        def process_job(j: DownloadJob, worker_id: int) -> str:
+            return f"Processed {j.url} by worker {worker_id}"
+
+        with WorkerPool[str](max_workers=2) as pool:
+            future = pool.submit_job(job, process_job, worker_id=0)
+            assert future is not None
+            result = future.result()
+            assert "Processed" in result
+            assert "worker 0" in result
+
+    def test_worker_state_tracking(self, temp_dir: Path) -> None:
+        """Test that worker state is tracked correctly."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+
+        def slow_task(_j: DownloadJob, _worker_id: int) -> str:
+            time.sleep(0.1)
+            return "done"
+
+        with WorkerPool[str](max_workers=2) as pool:
+            # Initially all workers are idle
+            assert len(pool.get_idle_workers()) == 2
+
+            # Submit a job
+            future = pool.submit_job(job, slow_task, worker_id=0)
+
+            # Worker 0 should now have the job
+            assert pool.worker_states[0].job == job
+
+            # Wait for completion
+            if future:
+                future.result()
+
+            # Mark worker as idle
+            pool.mark_worker_idle(0)
+            assert pool.worker_states[0].is_idle
+
+    def test_parallel_execution(self) -> None:
+        """Test that tasks run in parallel."""
+        start_times: dict[int, float] = {}
+        end_times: dict[int, float] = {}
+
+        def timed_task(task_id: int) -> int:
+            start_times[task_id] = time.time()
+            time.sleep(0.1)
+            end_times[task_id] = time.time()
+            return task_id
+
+        with WorkerPool[int](max_workers=4) as pool:
+            futures = [pool.submit(timed_task, i) for i in range(4)]
+            for future in futures:
+                if future:
+                    future.result()
+
+        # With 4 workers, tasks should overlap significantly
+        # If sequential, total time would be ~0.4s
+        # If parallel, total time should be ~0.1s
+        overall_start = min(start_times.values())
+        overall_end = max(end_times.values())
+        total_time = overall_end - overall_start
+
+        # Allow some margin, but should be much less than sequential time
+        assert total_time < 0.3
+
+    def test_wait_for_completion(self) -> None:
+        """Test waiting for futures to complete."""
+
+        def task(x: int) -> int:
+            time.sleep(0.01)
+            return x * 2
+
+        completed: list[int] = []
+
+        def on_complete(future: Future[int], _worker_id: int | None) -> None:
+            completed.append(future.result())
+
+        with WorkerPool[int](max_workers=2) as pool:
+            futures = [pool.submit(task, i) for i in range(4)]
+            valid_futures = [f for f in futures if f is not None]
+            results = pool.wait_for_completion(valid_futures, callback=on_complete)
+
+        assert len(completed) == 4
+        assert sorted(results) == [0, 2, 4, 6]
+
+    def test_shutdown_prevents_new_tasks(self) -> None:
+        """Test that shutdown prevents new task submission."""
+        with WorkerPool[int](max_workers=2) as pool:
+            # Trigger shutdown
+            pool.shutdown()
+            assert is_shutdown_requested()
+
+            # New submission should return None
+            future = pool.submit(lambda x: x, 1)
+            assert future is None
+
+    def test_get_active_and_idle_workers(self, temp_dir: Path) -> None:
+        """Test getting lists of active and idle workers."""
+        with WorkerPool[str](max_workers=4) as pool:
+            # Initially all idle
+            assert len(pool.get_idle_workers()) == 4
+            assert len(pool.get_active_workers()) == 0
+
+            # Simulate job assignment
+            job = DownloadJob(
+                url="https://youtube.com/watch?v=test",
+                output_dir=temp_dir,
+            )
+            pool.worker_states[0].job = job
+            pool.worker_states[1].job = job
+
+            assert len(pool.get_idle_workers()) == 2
+            assert len(pool.get_active_workers()) == 2

--- a/tests/batch/test_job.py
+++ b/tests/batch/test_job.py
@@ -1,0 +1,189 @@
+"""Unit tests for DownloadJob entity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from yt_audio_cli.batch.job import DownloadJob, JobStatus, ProgressUpdate
+
+
+class TestDownloadJob:
+    """Tests for DownloadJob dataclass."""
+
+    def test_create_valid_job(self, temp_dir: Path) -> None:
+        """Test creating a valid download job."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test123",
+            output_dir=temp_dir,
+            format="mp3",
+        )
+        assert job.url == "https://youtube.com/watch?v=test123"
+        assert job.output_dir == temp_dir
+        assert job.format == "mp3"
+        assert job.status == JobStatus.PENDING
+        assert job.retry_count == 0
+        assert job.error_message is None
+        assert job.output_path is None
+        assert job.current_percent == 0
+        assert job.current_title == ""
+
+    def test_invalid_url_raises(self, temp_dir: Path) -> None:
+        """Test that invalid URL raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid URL"):
+            DownloadJob(
+                url="not-a-valid-url",
+                output_dir=temp_dir,
+            )
+
+    def test_negative_retry_count_raises(self, temp_dir: Path) -> None:
+        """Test that negative retry count raises ValueError."""
+        with pytest.raises(ValueError, match="retry_count must be >= 0"):
+            DownloadJob(
+                url="https://youtube.com/watch?v=test",
+                output_dir=temp_dir,
+                retry_count=-1,
+            )
+
+    def test_percent_clamped_to_valid_range(self, temp_dir: Path) -> None:
+        """Test that percent is clamped to 0-100 range."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+            current_percent=150,
+        )
+        assert job.current_percent == 100
+
+        job2 = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+            current_percent=-10,
+        )
+        assert job2.current_percent == 0
+
+    def test_mark_active(self, temp_dir: Path) -> None:
+        """Test marking job as active."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+        job.mark_active(title="Test Video")
+        assert job.status == JobStatus.ACTIVE
+        assert job.current_percent == 0
+        assert job.current_title == "Test Video"
+
+    def test_mark_complete(self, temp_dir: Path) -> None:
+        """Test marking job as complete."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+        output_path = temp_dir / "test.mp3"
+        job.mark_complete(output_path)
+        assert job.status == JobStatus.COMPLETE
+        assert job.output_path == output_path
+        assert job.current_percent == 100
+        assert job.error_message is None
+
+    def test_mark_failed(self, temp_dir: Path) -> None:
+        """Test marking job as failed."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+        job.mark_failed("Connection timeout")
+        assert job.status == JobStatus.FAILED
+        assert job.error_message == "Connection timeout"
+
+    def test_mark_cancelled(self, temp_dir: Path) -> None:
+        """Test marking job as cancelled."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+        job.mark_cancelled()
+        assert job.status == JobStatus.CANCELLED
+
+    def test_update_progress(self, temp_dir: Path) -> None:
+        """Test updating progress."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+        job.update_progress(50, "Downloading...")
+        assert job.current_percent == 50
+        assert job.current_title == "Downloading..."
+
+        # Test clamping
+        job.update_progress(150)
+        assert job.current_percent == 100
+
+        job.update_progress(-10)
+        assert job.current_percent == 0
+
+    def test_increment_retry(self, temp_dir: Path) -> None:
+        """Test incrementing retry count."""
+        job = DownloadJob(
+            url="https://youtube.com/watch?v=test",
+            output_dir=temp_dir,
+        )
+        job.mark_failed("Error")
+        job.increment_retry()
+
+        assert job.retry_count == 1
+        assert job.status == JobStatus.PENDING
+        assert job.current_percent == 0
+        assert job.error_message is None
+
+
+class TestProgressUpdate:
+    """Tests for ProgressUpdate dataclass."""
+
+    def test_create_started_event(self) -> None:
+        """Test creating a started progress update."""
+        update = ProgressUpdate(
+            worker_id=0,
+            job_url="https://youtube.com/watch?v=test",
+            event="started",
+        )
+        assert update.worker_id == 0
+        assert update.job_url == "https://youtube.com/watch?v=test"
+        assert update.event == "started"
+        assert update.percent == 0
+        assert update.title == ""
+        assert update.error == ""
+
+    def test_create_progress_event(self) -> None:
+        """Test creating a progress update."""
+        update = ProgressUpdate(
+            worker_id=1,
+            job_url="https://youtube.com/watch?v=test",
+            event="progress",
+            percent=50,
+            title="Test Video",
+        )
+        assert update.event == "progress"
+        assert update.percent == 50
+        assert update.title == "Test Video"
+
+    def test_create_failed_event(self) -> None:
+        """Test creating a failed progress update."""
+        update = ProgressUpdate(
+            worker_id=2,
+            job_url="https://youtube.com/watch?v=test",
+            event="failed",
+            error="Connection timeout",
+        )
+        assert update.event == "failed"
+        assert update.error == "Connection timeout"
+
+    def test_progress_update_is_immutable(self) -> None:
+        """Test that ProgressUpdate is frozen (immutable)."""
+        update = ProgressUpdate(
+            worker_id=0,
+            job_url="https://youtube.com/watch?v=test",
+            event="started",
+        )
+        with pytest.raises(AttributeError):
+            update.worker_id = 1  # type: ignore[misc]

--- a/tests/batch/test_request.py
+++ b/tests/batch/test_request.py
@@ -94,14 +94,19 @@ class TestBatchRequest:
         assert pending[0].url == "https://youtube.com/watch?v=test2"
 
     def test_pending_jobs_includes_retryable_failed(self, temp_dir: Path) -> None:
-        """Test that failed jobs with retries remaining are included."""
+        """Test that failed jobs with retries remaining are included.
+
+        Note: pending_jobs() is a pure iterator that doesn't modify job status.
+        It yields failed jobs that are eligible for retry.
+        """
         job = DownloadJob(url="https://youtube.com/watch?v=test", output_dir=temp_dir)
         job.mark_failed("Timeout")
         request = BatchRequest(jobs=[job], max_retries=3)
 
         pending = list(request.pending_jobs())
         assert len(pending) == 1
-        assert pending[0].status == JobStatus.PENDING
+        # Status remains FAILED - iterator doesn't mutate jobs
+        assert pending[0].status == JobStatus.FAILED
 
     def test_pending_jobs_excludes_exhausted_retries(self, temp_dir: Path) -> None:
         """Test that failed jobs with exhausted retries are excluded."""

--- a/tests/batch/test_request.py
+++ b/tests/batch/test_request.py
@@ -1,0 +1,281 @@
+"""Unit tests for BatchRequest and BatchResult entities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from yt_audio_cli.batch.job import DownloadJob, JobStatus
+from yt_audio_cli.batch.request import (
+    BatchRequest,
+    BatchResult,
+    deduplicate_urls,
+    normalize_url,
+    parse_batch_file,
+)
+
+
+class TestBatchRequest:
+    """Tests for BatchRequest dataclass."""
+
+    def test_create_empty_request(self) -> None:
+        """Test creating an empty batch request."""
+        request = BatchRequest()
+        assert request.total == 0
+        assert request.completed == 0
+        assert request.failed == 0
+        assert request.pending == 0
+        assert request.max_workers == 4
+        assert request.max_retries == 3
+
+    def test_create_request_with_jobs(self, temp_dir: Path) -> None:
+        """Test creating a request with jobs."""
+        jobs = [
+            DownloadJob(url="https://youtube.com/watch?v=test1", output_dir=temp_dir),
+            DownloadJob(url="https://youtube.com/watch?v=test2", output_dir=temp_dir),
+        ]
+        request = BatchRequest(jobs=jobs, max_workers=8)
+        assert request.total == 2
+        assert request.pending == 2
+        assert request.max_workers == 8
+
+    def test_invalid_max_workers_low(self) -> None:
+        """Test that max_workers < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="max_workers must be >= 1"):
+            BatchRequest(max_workers=0)
+
+    def test_invalid_max_workers_high(self) -> None:
+        """Test that max_workers > 16 raises ValueError."""
+        with pytest.raises(ValueError, match="max_workers must be <= 16"):
+            BatchRequest(max_workers=17)
+
+    def test_invalid_max_retries_low(self) -> None:
+        """Test that max_retries < 0 raises ValueError."""
+        with pytest.raises(ValueError, match="max_retries must be >= 0"):
+            BatchRequest(max_retries=-1)
+
+    def test_invalid_max_retries_high(self) -> None:
+        """Test that max_retries > 10 raises ValueError."""
+        with pytest.raises(ValueError, match="max_retries must be <= 10"):
+            BatchRequest(max_retries=11)
+
+    def test_thread_safe_counters(self, temp_dir: Path) -> None:
+        """Test that counters are thread-safe."""
+        request = BatchRequest()
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        request.increment_completed()
+        assert request.completed == 1
+
+        request.increment_failed()
+        assert request.failed == 1
+
+    def test_add_job(self, temp_dir: Path) -> None:
+        """Test adding a job to the request."""
+        request = BatchRequest()
+        request.add_job("https://youtube.com/watch?v=test", temp_dir, "opus")
+
+        assert request.total == 1
+        assert request.jobs[0].url == "https://youtube.com/watch?v=test"
+        assert request.jobs[0].format == "opus"
+
+    def test_pending_jobs_iterator(self, temp_dir: Path) -> None:
+        """Test iterating over pending jobs."""
+        jobs = [
+            DownloadJob(url="https://youtube.com/watch?v=test1", output_dir=temp_dir),
+            DownloadJob(url="https://youtube.com/watch?v=test2", output_dir=temp_dir),
+        ]
+        jobs[0].status = JobStatus.COMPLETE
+        request = BatchRequest(jobs=jobs)
+
+        pending = list(request.pending_jobs())
+        assert len(pending) == 1
+        assert pending[0].url == "https://youtube.com/watch?v=test2"
+
+    def test_pending_jobs_includes_retryable_failed(self, temp_dir: Path) -> None:
+        """Test that failed jobs with retries remaining are included."""
+        job = DownloadJob(url="https://youtube.com/watch?v=test", output_dir=temp_dir)
+        job.mark_failed("Timeout")
+        request = BatchRequest(jobs=[job], max_retries=3)
+
+        pending = list(request.pending_jobs())
+        assert len(pending) == 1
+        assert pending[0].status == JobStatus.PENDING
+
+    def test_pending_jobs_excludes_exhausted_retries(self, temp_dir: Path) -> None:
+        """Test that failed jobs with exhausted retries are excluded."""
+        job = DownloadJob(url="https://youtube.com/watch?v=test", output_dir=temp_dir)
+        job.mark_failed("Timeout")
+        job.retry_count = 3
+        request = BatchRequest(jobs=[job], max_retries=3)
+
+        pending = list(request.pending_jobs())
+        assert len(pending) == 0
+
+
+class TestBatchResult:
+    """Tests for BatchResult dataclass."""
+
+    def test_create_result(self, temp_dir: Path) -> None:
+        """Test creating a batch result."""
+        result = BatchResult(
+            total=10,
+            successful=8,
+            failed=2,
+            skipped_duplicates=1,
+            successful_files=[temp_dir / "test.mp3"],
+        )
+        assert result.total == 10
+        assert result.successful == 8
+        assert result.failed == 2
+        assert result.skipped_duplicates == 1
+
+    def test_success_rate(self) -> None:
+        """Test success rate calculation."""
+        result = BatchResult(total=10, successful=8, failed=2, skipped_duplicates=0)
+        assert result.success_rate == 0.8
+
+    def test_success_rate_empty(self) -> None:
+        """Test success rate with no jobs."""
+        result = BatchResult(total=0, successful=0, failed=0, skipped_duplicates=0)
+        assert result.success_rate == 1.0
+
+    def test_has_failures(self) -> None:
+        """Test has_failures property."""
+        result_with_failures = BatchResult(
+            total=10, successful=8, failed=2, skipped_duplicates=0
+        )
+        assert result_with_failures.has_failures is True
+
+        result_without_failures = BatchResult(
+            total=10, successful=10, failed=0, skipped_duplicates=0
+        )
+        assert result_without_failures.has_failures is False
+
+    def test_from_request(self, temp_dir: Path) -> None:
+        """Test creating result from a completed request."""
+        jobs = [
+            DownloadJob(url="https://youtube.com/watch?v=test1", output_dir=temp_dir),
+            DownloadJob(url="https://youtube.com/watch?v=test2", output_dir=temp_dir),
+        ]
+        jobs[0].mark_complete(temp_dir / "test1.mp3")
+        jobs[1].mark_failed("Error")
+
+        request = BatchRequest(jobs=jobs)
+        result = BatchResult.from_request(request, skipped=1)
+
+        assert result.total == 2
+        assert result.successful == 1
+        assert result.failed == 1
+        assert result.skipped_duplicates == 1
+        assert len(result.successful_files) == 1
+        assert len(result.failed_jobs) == 1
+
+
+class TestParseBatchFile:
+    """Tests for parse_batch_file function."""
+
+    def test_parse_valid_file(self, temp_dir: Path) -> None:
+        """Test parsing a valid batch file."""
+        batch_file = temp_dir / "urls.txt"
+        batch_file.write_text(
+            """# This is a comment
+https://youtube.com/watch?v=test1
+
+# Another comment
+https://youtube.com/watch?v=test2
+https://youtube.com/watch?v=test3
+"""
+        )
+
+        urls = parse_batch_file(batch_file)
+        assert len(urls) == 3
+        assert urls[0] == "https://youtube.com/watch?v=test1"
+        assert urls[1] == "https://youtube.com/watch?v=test2"
+        assert urls[2] == "https://youtube.com/watch?v=test3"
+
+    def test_parse_file_not_found(self, temp_dir: Path) -> None:
+        """Test that missing file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="Batch file not found"):
+            parse_batch_file(temp_dir / "nonexistent.txt")
+
+    def test_parse_empty_file(self, temp_dir: Path) -> None:
+        """Test that empty file raises ValueError."""
+        batch_file = temp_dir / "empty.txt"
+        batch_file.write_text("")
+
+        with pytest.raises(ValueError, match="Batch file is empty"):
+            parse_batch_file(batch_file)
+
+    def test_parse_comments_only_file(self, temp_dir: Path) -> None:
+        """Test that file with only comments raises ValueError."""
+        batch_file = temp_dir / "comments.txt"
+        batch_file.write_text("# Just a comment\n# Another comment\n")
+
+        with pytest.raises(ValueError, match="Batch file is empty"):
+            parse_batch_file(batch_file)
+
+
+class TestNormalizeUrl:
+    """Tests for normalize_url function."""
+
+    def test_normalize_standard_youtube(self) -> None:
+        """Test normalizing standard YouTube URLs."""
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert normalize_url(url) == "youtube:dQw4w9WgXcQ"
+
+    def test_normalize_youtu_be(self) -> None:
+        """Test normalizing youtu.be short URLs."""
+        url = "https://youtu.be/dQw4w9WgXcQ"
+        assert normalize_url(url) == "youtube:dQw4w9WgXcQ"
+
+    def test_normalize_youtube_embed(self) -> None:
+        """Test normalizing YouTube embed URLs."""
+        url = "https://www.youtube.com/embed/dQw4w9WgXcQ"
+        assert normalize_url(url) == "youtube:dQw4w9WgXcQ"
+
+    def test_normalize_with_trailing_slash(self) -> None:
+        """Test that trailing slashes are removed."""
+        url = "https://example.com/video/"
+        assert normalize_url(url) == "https://example.com/video"
+
+    def test_normalize_non_youtube(self) -> None:
+        """Test normalizing non-YouTube URLs."""
+        url = "https://vimeo.com/12345"
+        assert normalize_url(url) == "https://vimeo.com/12345"
+
+
+class TestDeduplicateUrls:
+    """Tests for deduplicate_urls function."""
+
+    def test_no_duplicates(self) -> None:
+        """Test with no duplicates."""
+        urls = [
+            "https://youtube.com/watch?v=abc",
+            "https://youtube.com/watch?v=def",
+        ]
+        unique, dupes = deduplicate_urls(urls)
+        assert len(unique) == 2
+        assert len(dupes) == 0
+
+    def test_exact_duplicates(self) -> None:
+        """Test with exact duplicate URLs."""
+        urls = [
+            "https://youtube.com/watch?v=abc",
+            "https://youtube.com/watch?v=abc",
+        ]
+        unique, dupes = deduplicate_urls(urls)
+        assert len(unique) == 1
+        assert len(dupes) == 1
+
+    def test_normalized_duplicates(self) -> None:
+        """Test detecting duplicates across URL formats."""
+        urls = [
+            "https://youtube.com/watch?v=dQw4w9WgXcQ",
+            "https://youtu.be/dQw4w9WgXcQ",
+            "https://www.youtube.com/embed/dQw4w9WgXcQ",
+        ]
+        unique, dupes = deduplicate_urls(urls)
+        assert len(unique) == 1
+        assert len(dupes) == 2

--- a/tests/batch/test_retry.py
+++ b/tests/batch/test_retry.py
@@ -1,0 +1,145 @@
+"""Unit tests for RetryConfig and retry logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from yt_audio_cli.batch.retry import (
+    RetryConfig,
+    is_permanent_error,
+    is_retryable_error,
+)
+
+
+class TestRetryConfig:
+    """Tests for RetryConfig dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = RetryConfig()
+        assert config.max_attempts == 3
+        assert config.base_delay == 1.0
+        assert config.max_delay == 30.0
+        assert config.jitter is True
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = RetryConfig(
+            max_attempts=5,
+            base_delay=2.0,
+            max_delay=60.0,
+            jitter=False,
+        )
+        assert config.max_attempts == 5
+        assert config.base_delay == 2.0
+        assert config.max_delay == 60.0
+        assert config.jitter is False
+
+    def test_invalid_max_attempts_low(self) -> None:
+        """Test that max_attempts < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="max_attempts must be >= 1"):
+            RetryConfig(max_attempts=0)
+
+    def test_invalid_max_attempts_high(self) -> None:
+        """Test that max_attempts > 10 raises ValueError."""
+        with pytest.raises(ValueError, match="max_attempts must be <= 10"):
+            RetryConfig(max_attempts=11)
+
+    def test_invalid_base_delay(self) -> None:
+        """Test that negative base_delay raises ValueError."""
+        with pytest.raises(ValueError, match="base_delay must be >= 0"):
+            RetryConfig(base_delay=-1.0)
+
+    def test_invalid_max_delay(self) -> None:
+        """Test that max_delay < base_delay raises ValueError."""
+        with pytest.raises(ValueError, match=r"max_delay .* must be >= base_delay"):
+            RetryConfig(base_delay=10.0, max_delay=5.0)
+
+    def test_delay_for_attempt_exponential(self) -> None:
+        """Test exponential backoff calculation."""
+        config = RetryConfig(base_delay=1.0, max_delay=30.0, jitter=False)
+
+        assert config.delay_for_attempt(0) == 1.0  # 1 * 2^0 = 1
+        assert config.delay_for_attempt(1) == 2.0  # 1 * 2^1 = 2
+        assert config.delay_for_attempt(2) == 4.0  # 1 * 2^2 = 4
+        assert config.delay_for_attempt(3) == 8.0  # 1 * 2^3 = 8
+        assert config.delay_for_attempt(4) == 16.0  # 1 * 2^4 = 16
+        assert config.delay_for_attempt(5) == 30.0  # capped at max_delay
+
+    def test_delay_for_attempt_with_jitter(self) -> None:
+        """Test that jitter adds randomness to delay."""
+        config = RetryConfig(base_delay=1.0, max_delay=30.0, jitter=True)
+
+        delay = config.delay_for_attempt(0)
+        # Base delay is 1.0, jitter adds 0-1, so delay should be 1.0-2.0
+        assert 1.0 <= delay <= 2.0
+
+    def test_delay_for_negative_attempt(self) -> None:
+        """Test that negative attempt number is treated as 0."""
+        config = RetryConfig(base_delay=1.0, jitter=False)
+        assert config.delay_for_attempt(-1) == 1.0
+
+    def test_should_retry(self) -> None:
+        """Test should_retry logic."""
+        config = RetryConfig(max_attempts=3)
+
+        assert config.should_retry(0) is True  # Can retry after attempt 0
+        assert config.should_retry(1) is True  # Can retry after attempt 1
+        assert config.should_retry(2) is False  # No retry after attempt 2 (3rd attempt)
+        assert config.should_retry(3) is False  # Definitely no more retries
+
+
+class TestRetryableErrors:
+    """Tests for error classification functions."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            "Connection timeout",
+            "connection reset by peer",
+            "temporary failure in name resolution",
+            "HTTP Error 429: Too Many Requests",
+            "503 Service Unavailable",
+            "Network is unreachable",
+            "Read timed out",
+            "SSL Error: Connection reset",
+        ],
+    )
+    def test_retryable_errors(self, error: str) -> None:
+        """Test that transient errors are classified as retryable."""
+        assert is_retryable_error(error) is True
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            "Video unavailable",
+            "This video is private",
+            "HTTP Error 404: Not Found",
+            "This video has been removed",
+            "Sign in to confirm your age",
+            "This video is age-restricted",
+            "Video is blocked in your country",
+            "This video is only available to members",
+            "Copyright claim",
+        ],
+    )
+    def test_permanent_errors(self, error: str) -> None:
+        """Test that permanent errors are not retryable."""
+        assert is_retryable_error(error) is False
+        assert is_permanent_error(error) is True
+
+    def test_empty_error_not_retryable(self) -> None:
+        """Test that empty error is not retryable."""
+        assert is_retryable_error("") is False
+        assert is_permanent_error("") is False
+
+    def test_unknown_error_not_retryable(self) -> None:
+        """Test that unknown errors are not retryable by default."""
+        assert is_retryable_error("Some random error message") is False
+
+    def test_permanent_error_takes_precedence(self) -> None:
+        """Test that permanent error patterns take precedence."""
+        # This contains both "timeout" (retryable) and "video unavailable" (permanent)
+        error = "timeout while checking video unavailable status"
+        assert is_retryable_error(error) is False
+        assert is_permanent_error(error) is True

--- a/tests/download/test_batch.py
+++ b/tests/download/test_batch.py
@@ -8,9 +8,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from yt_audio_cli.batch.executor import reset_shutdown
+from yt_audio_cli.batch.executor import reset_shutdown, shutdown_event
 from yt_audio_cli.batch.job import ProgressUpdate
 from yt_audio_cli.batch.request import BatchRequest
+from yt_audio_cli.batch.retry import RetryConfig
 from yt_audio_cli.download.batch import BatchDownloader, download_batch
 from yt_audio_cli.download.downloader import DownloadResult
 
@@ -308,3 +309,292 @@ class TestDownloadBatch:
         assert result.total == 1
         assert result.failed == 1
         assert result.has_failures is True
+
+
+class TestBatchDownloaderEdgeCases:
+    """Tests for edge cases in BatchDownloader."""
+
+    @patch("yt_audio_cli.download.batch.download")
+    def test_shutdown_at_start(
+        self,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test shutdown requested before download starts."""
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        # Request shutdown before running
+        shutdown_event.set()
+
+        result = downloader.run()
+        # Job should be cancelled - not counted as failed or successful
+        assert result.successful == 0
+        assert result.total == 1
+        mock_download.assert_not_called()
+
+    @patch("yt_audio_cli.download.batch.download")
+    def test_temp_file_not_found(
+        self,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test handling when temp file doesn't exist after download."""
+        # Return success but with non-existent temp path
+        mock_download.return_value = DownloadResult(
+            url="https://youtube.com/watch?v=test",
+            title="Test Video",
+            artist="Test Artist",
+            temp_path=temp_dir / "nonexistent.webm",
+            duration=120.0,
+            success=True,
+        )
+
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        result = downloader.run()
+        assert result.failed == 1
+        assert "not found" in result.failed_jobs[0].error_message.lower()
+
+    @patch("yt_audio_cli.download.batch.download")
+    def test_download_raises_exception(
+        self,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test handling when download raises an exception."""
+        mock_download.side_effect = RuntimeError("Unexpected error")
+
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        result = downloader.run()
+        assert result.failed == 1
+        assert "unexpected error" in result.failed_jobs[0].error_message.lower()
+
+    @patch("yt_audio_cli.download.batch.download")
+    @patch("yt_audio_cli.download.batch.transcode")
+    def test_conversion_raises_exception(
+        self,
+        mock_transcode: MagicMock,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test handling when conversion raises an exception."""
+        temp_audio = temp_dir / "temp_audio.webm"
+        temp_audio.write_bytes(b"fake audio data")
+
+        mock_download.return_value = DownloadResult(
+            url="https://youtube.com/watch?v=test",
+            title="Test Video",
+            artist="Test Artist",
+            temp_path=temp_audio,
+            duration=120.0,
+            success=True,
+        )
+        mock_transcode.side_effect = RuntimeError("Conversion error")
+
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        result = downloader.run()
+        assert result.failed == 1
+        assert "conversion" in result.failed_jobs[0].error_message.lower()
+
+    @patch("yt_audio_cli.download.batch.download")
+    @patch("yt_audio_cli.download.batch.time.sleep")
+    def test_retry_on_retryable_error(
+        self,
+        mock_sleep: MagicMock,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test retry logic for retryable errors."""
+        call_count = [0]
+
+        def download_with_retry(**kwargs):
+            call_count[0] += 1
+            if call_count[0] < 2:
+                # First call fails with retryable error
+                return DownloadResult(
+                    url=kwargs.get("url"),
+                    title="",
+                    artist="",
+                    temp_path=Path(),
+                    duration=None,
+                    success=False,
+                    error="Connection timeout",
+                )
+            # Second call succeeds
+            output_dir = kwargs.get("output_dir")
+            temp_audio = output_dir / "temp.webm"
+            temp_audio.write_bytes(b"data")
+            return DownloadResult(
+                url=kwargs.get("url"),
+                title="Test",
+                artist="Artist",
+                temp_path=temp_audio,
+                duration=60.0,
+                success=True,
+            )
+
+        mock_download.side_effect = download_with_retry
+
+        request = BatchRequest(max_workers=1, max_retries=3)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        retry_config = RetryConfig(max_attempts=3, base_delay=0.01)
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+            retry_config=retry_config,
+        )
+
+        # Mock transcode to succeed
+        with patch("yt_audio_cli.download.batch.transcode") as mock_transcode:
+
+            def create_output(*args, **kwargs):
+                output_path = args[1] if len(args) > 1 else kwargs.get("output_path")
+                if output_path:
+                    output_path.write_bytes(b"converted")
+                return True
+
+            mock_transcode.side_effect = create_output
+            downloader.run()
+
+        # Should retry and eventually succeed
+        assert call_count[0] == 2
+        assert mock_sleep.called
+
+    @patch("yt_audio_cli.download.batch.download")
+    def test_no_retry_on_permanent_error(
+        self,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test no retry for permanent errors like 'Video unavailable'."""
+        mock_download.return_value = DownloadResult(
+            url="https://youtube.com/watch?v=test",
+            title="",
+            artist="",
+            temp_path=Path(),
+            duration=None,
+            success=False,
+            error="Video unavailable",
+        )
+
+        request = BatchRequest(max_workers=1, max_retries=3)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        retry_config = RetryConfig(max_attempts=3)
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+            retry_config=retry_config,
+        )
+
+        result = downloader.run()
+        # Should fail immediately without retrying
+        assert result.failed == 1
+        assert mock_download.call_count == 1
+
+    @patch("yt_audio_cli.download.batch.download")
+    @patch("yt_audio_cli.download.batch.transcode")
+    def test_shutdown_after_download(
+        self,
+        mock_transcode: MagicMock,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test shutdown requested after download but before conversion."""
+        temp_audio = temp_dir / "temp_audio.webm"
+        temp_audio.write_bytes(b"fake audio data")
+
+        def download_and_shutdown(**kwargs):
+            # Request shutdown after download
+            shutdown_event.set()
+            return DownloadResult(
+                url=kwargs.get("url"),
+                title="Test Video",
+                artist="Test Artist",
+                temp_path=temp_audio,
+                duration=120.0,
+                success=True,
+            )
+
+        mock_download.side_effect = download_and_shutdown
+
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        result = downloader.run()
+        # Should be cancelled - not counted as failed or successful
+        assert result.successful == 0
+        assert result.total == 1
+        mock_transcode.assert_not_called()
+
+    @patch("yt_audio_cli.download.batch.download")
+    @patch("yt_audio_cli.download.batch.transcode")
+    def test_download_without_title(
+        self,
+        mock_transcode: MagicMock,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test download result with empty title."""
+        temp_audio = temp_dir / "temp_audio.webm"
+        temp_audio.write_bytes(b"fake audio data")
+
+        mock_download.return_value = DownloadResult(
+            url="https://youtube.com/watch?v=test",
+            title="",  # Empty title
+            artist="Test Artist",
+            temp_path=temp_audio,
+            duration=120.0,
+            success=True,
+        )
+
+        def create_output(*args, **kwargs):
+            output_path = args[1] if len(args) > 1 else kwargs.get("output_path")
+            if output_path:
+                output_path.write_bytes(b"converted audio")
+            return True
+
+        mock_transcode.side_effect = create_output
+
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        result = downloader.run()
+        assert result.successful == 1

--- a/tests/download/test_batch.py
+++ b/tests/download/test_batch.py
@@ -1,0 +1,310 @@
+"""Tests for batch download functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from queue import Queue
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from yt_audio_cli.batch.executor import reset_shutdown
+from yt_audio_cli.batch.job import ProgressUpdate
+from yt_audio_cli.batch.request import BatchRequest
+from yt_audio_cli.download.batch import BatchDownloader, download_batch
+from yt_audio_cli.download.downloader import DownloadResult
+
+
+@pytest.fixture(autouse=True)
+def reset_shutdown_state() -> None:
+    """Reset shutdown state before each test."""
+    reset_shutdown()
+
+
+class TestBatchDownloader:
+    """Tests for BatchDownloader class."""
+
+    def test_empty_request(self, temp_dir: Path) -> None:
+        """Test processing an empty batch request."""
+        request = BatchRequest()
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        result = downloader.run()
+        assert result.total == 0
+        assert result.successful == 0
+        assert result.failed == 0
+
+    @patch("yt_audio_cli.download.batch.download")
+    @patch("yt_audio_cli.download.batch.transcode")
+    def test_successful_download(
+        self,
+        mock_transcode: MagicMock,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test successful download and conversion."""
+        # Create temp file to simulate download
+        temp_audio = temp_dir / "temp_audio.webm"
+        temp_audio.write_bytes(b"fake audio data")
+
+        mock_download.return_value = DownloadResult(
+            url="https://youtube.com/watch?v=test",
+            title="Test Video",
+            artist="Test Artist",
+            temp_path=temp_audio,
+            duration=120.0,
+            success=True,
+        )
+        mock_transcode.return_value = True
+
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        # Create output file to simulate conversion
+        def create_output(*args, **kwargs):
+            output_path = args[1] if len(args) > 1 else kwargs.get("output_path")
+            if output_path:
+                output_path.write_bytes(b"converted audio")
+            return True
+
+        mock_transcode.side_effect = create_output
+
+        result = downloader.run()
+        assert result.total == 1
+        assert result.successful == 1
+        assert result.failed == 0
+
+    @patch("yt_audio_cli.download.batch.download")
+    def test_failed_download(
+        self,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test handling of failed download."""
+        mock_download.return_value = DownloadResult(
+            url="https://youtube.com/watch?v=test",
+            title="",
+            artist="",
+            temp_path=Path(),
+            duration=None,
+            success=False,
+            error="Video unavailable",
+        )
+
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        result = downloader.run()
+        assert result.total == 1
+        assert result.successful == 0
+        assert result.failed == 1
+        assert len(result.failed_jobs) == 1
+
+    @patch("yt_audio_cli.download.batch.download")
+    @patch("yt_audio_cli.download.batch.transcode")
+    def test_progress_updates(
+        self,
+        mock_transcode: MagicMock,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test that progress updates are sent to queue."""
+        temp_audio = temp_dir / "temp_audio.webm"
+        temp_audio.write_bytes(b"fake audio data")
+
+        def download_with_progress(**kwargs):
+            url = kwargs.get("url")
+            progress_callback = kwargs.get("progress_callback")
+            # Simulate progress updates
+            if progress_callback:
+                progress_callback(50, 100)
+                progress_callback(100, 100)
+            return DownloadResult(
+                url=url,
+                title="Test Video",
+                artist="Test Artist",
+                temp_path=temp_audio,
+                duration=120.0,
+                success=True,
+            )
+
+        mock_download.side_effect = download_with_progress
+
+        def create_output(*args, **kwargs):
+            output_path = args[1] if len(args) > 1 else kwargs.get("output_path")
+            if output_path:
+                output_path.write_bytes(b"converted audio")
+            return True
+
+        mock_transcode.side_effect = create_output
+
+        progress_queue: Queue[ProgressUpdate] = Queue()
+        request = BatchRequest(max_workers=1)
+        request.add_job("https://youtube.com/watch?v=test", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+            progress_queue=progress_queue,
+        )
+
+        result = downloader.run()
+        assert result.successful == 1
+
+        # Check that progress updates were sent
+        updates = []
+        while not progress_queue.empty():
+            updates.append(progress_queue.get())
+
+        # Should have started, progress, and complete events
+        events = [u.event for u in updates]
+        assert "started" in events
+        assert "complete" in events
+
+    @patch("yt_audio_cli.download.batch.download")
+    @patch("yt_audio_cli.download.batch.transcode")
+    def test_multiple_parallel_downloads(
+        self,
+        mock_transcode: MagicMock,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test parallel download of multiple URLs."""
+        call_count = [0]
+
+        def create_download_result(**kwargs):
+            url = kwargs.get("url")
+            output_dir = kwargs.get("output_dir")
+            call_count[0] += 1
+            # Create a unique temp file for each call
+            temp_audio = output_dir / f"temp_audio_{call_count[0]}.webm"
+            temp_audio.write_bytes(b"fake audio data")
+            return DownloadResult(
+                url=url,
+                title=f"Test Video {call_count[0]}",
+                artist="Test Artist",
+                temp_path=temp_audio,
+                duration=120.0,
+                success=True,
+            )
+
+        mock_download.side_effect = create_download_result
+
+        def create_output(*args, **kwargs):
+            output_path = args[1] if len(args) > 1 else kwargs.get("output_path")
+            if output_path:
+                output_path.write_bytes(b"converted audio")
+            return True
+
+        mock_transcode.side_effect = create_output
+
+        request = BatchRequest(max_workers=4)
+        for i in range(10):
+            request.add_job(f"https://youtube.com/watch?v=test{i}", temp_dir)
+
+        downloader = BatchDownloader(
+            request=request,
+            output_dir=temp_dir,
+        )
+
+        result = downloader.run()
+        assert result.total == 10
+        assert result.successful == 10
+        assert result.failed == 0
+
+
+class TestDownloadBatch:
+    """Tests for download_batch convenience function."""
+
+    @patch("yt_audio_cli.download.batch.download")
+    @patch("yt_audio_cli.download.batch.transcode")
+    def test_download_batch_function(
+        self,
+        mock_transcode: MagicMock,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test the download_batch convenience function."""
+        call_count = [0]
+
+        def create_download_result(**kwargs):
+            url = kwargs.get("url")
+            output_dir = kwargs.get("output_dir")
+            call_count[0] += 1
+            temp_audio = output_dir / f"temp_audio_{call_count[0]}.webm"
+            temp_audio.write_bytes(b"fake audio data")
+            return DownloadResult(
+                url=url,
+                title=f"Test Video {call_count[0]}",
+                artist="Test Artist",
+                temp_path=temp_audio,
+                duration=120.0,
+                success=True,
+            )
+
+        mock_download.side_effect = create_download_result
+
+        def create_output(*args, **kwargs):
+            output_path = args[1] if len(args) > 1 else kwargs.get("output_path")
+            if output_path:
+                output_path.write_bytes(b"converted audio")
+            return True
+
+        mock_transcode.side_effect = create_output
+
+        urls = [
+            "https://youtube.com/watch?v=test1",
+            "https://youtube.com/watch?v=test2",
+        ]
+
+        result = download_batch(
+            urls=urls,
+            output_dir=temp_dir,
+            audio_format="mp3",
+            max_workers=2,
+        )
+
+        assert result.total == 2
+        assert result.successful == 2
+
+    @patch("yt_audio_cli.download.batch.download")
+    def test_download_batch_with_failures(
+        self,
+        mock_download: MagicMock,
+        temp_dir: Path,
+    ) -> None:
+        """Test download_batch with some failures."""
+        mock_download.return_value = DownloadResult(
+            url="https://youtube.com/watch?v=test",
+            title="",
+            artist="",
+            temp_path=Path(),
+            duration=None,
+            success=False,
+            error="Video unavailable",
+        )
+
+        urls = ["https://youtube.com/watch?v=test1"]
+
+        result = download_batch(
+            urls=urls,
+            output_dir=temp_dir,
+            max_workers=1,
+        )
+
+        assert result.total == 1
+        assert result.failed == 1
+        assert result.has_failures is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,9 +37,11 @@ class TestCLIArgumentParsing:
 
     def test_version_flag(self, runner: CliRunner, cli_app: Any) -> None:
         """Test --version flag shows version."""
+        from yt_audio_cli import __version__
+
         result = runner.invoke(cli_app, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.1" in result.output
+        assert __version__ in result.output
 
     def test_no_urls_shows_error(self, runner: CliRunner, cli_app: Any) -> None:
         """Test that missing URLs shows error."""

--- a/uv.lock
+++ b/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "yt-audio-cli"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Description

Add performance optimization features for downloading multiple audio files:

- **Parallel downloads**: Configurable concurrent workers (`--workers/-w`, default 4, max 16)
- **Batch file processing**: Load URLs from a text file (`--batch/-b`)
- **Retry with exponential backoff**: Configurable retry attempts (`--retries/-r`, default 3)
- **Graceful shutdown**: Handle SIGINT/SIGTERM for clean cancellation
- **Smart error classification**: Retry network errors, skip permanent errors (private/unavailable videos)

## Related Issue

N/A - New feature implementation

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make format` and `make lint`
- [x] I have run `make typecheck` with no errors
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated documentation if needed

## Testing

- Added 79 new tests for batch module (`tests/batch/`)
- Added 7 new tests for batch downloads (`tests/download/test_batch.py`)
- Added 4 new tests for CLI batch options (`tests/test_cli.py`)
- All 295 tests pass
- Manual testing with real YouTube videos confirmed parallel downloads work

## New Files

```
src/yt_audio_cli/batch/
├── __init__.py      # Module exports
├── job.py           # DownloadJob, JobStatus, ProgressUpdate
├── retry.py         # RetryConfig, exponential backoff
├── request.py       # BatchRequest, BatchResult, URL parsing
└── executor.py      # WorkerPool, signal handling

src/yt_audio_cli/download/batch.py  # BatchDownloader
```

## Usage Examples

```bash
# Parallel download with 8 workers
yt-audio-cli -w 8 URL1 URL2 URL3

# Download from batch file
yt-audio-cli --batch urls.txt

# Combine batch + URLs with retry
yt-audio-cli --batch urls.txt URL1 -r 5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel downloads (--workers / -w), batch-file support (--batch / -b; combine with CLI URLs), and automatic retries (--retries / -r) with parallel workflow and summary reporting.
* **Documentation**
  * Added guides and examples for Parallel Downloads, Batch Files (format/combining), and Retry Failed Downloads; updated options table and examples.
* **Chores**
  * CLI help short flag removed; package version bumped to 0.2.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->